### PR TITLE
ランキング一覧のUI修正

### DIFF
--- a/src/components/ranking/UsersRankings.tsx
+++ b/src/components/ranking/UsersRankings.tsx
@@ -19,9 +19,9 @@ const UsersRankings: React.FC<UsersRankingsProps> = ({ data }) => {
             <Typography
               variant="h6"
               component="span"
-              sx={{ color: "text.secondary", ml: 4 }}
+              sx={{ color: "text.secondary", marginLeft: 30 }}
             >
-              GeekLink Activities
+              GeekLinkアクティビティ数
             </Typography>
             {[{ data: activity, type: "activity" }].map((ranking, index) => (
               <Box key={index} p={2} borderRadius={1}>
@@ -38,9 +38,9 @@ const UsersRankings: React.FC<UsersRankingsProps> = ({ data }) => {
             <Typography
               variant="h6"
               component="span"
-              sx={{ color: "text.secondary", ml: 4 }}
+              sx={{ color: "text.secondary", marginLeft: 30 }}
             >
-              GitHub Contributions
+              GitHubコントリビューション数
             </Typography>
             {[{ data: contribution, type: "contribution" }].map(
               (ranking, index) => (
@@ -61,9 +61,9 @@ const UsersRankings: React.FC<UsersRankingsProps> = ({ data }) => {
             <Typography
               variant="h6"
               component="span"
-              sx={{ color: "text.secondary", ml: 4 }}
+              sx={{ color: "text.secondary", marginLeft: 37 }}
             >
-              GitHub Stars
+              GitHubスター数
             </Typography>
             {[{ data: star, type: "star" }].map((ranking, index) => (
               <Box key={index} p={2} borderRadius={1}>
@@ -80,9 +80,9 @@ const UsersRankings: React.FC<UsersRankingsProps> = ({ data }) => {
             <Typography
               variant="h6"
               component="span"
-              sx={{ color: "text.secondary", ml: 4 }}
+              sx={{ color: "text.secondary", marginLeft: 42 }}
             >
-              Qiita Posts
+              Qiita投稿数
             </Typography>
             {[{ data: qiita, type: "qiita" }].map((ranking, index) => (
               <Box key={index} p={2} borderRadius={1}>

--- a/src/components/top-page/UserRanking.tsx
+++ b/src/components/top-page/UserRanking.tsx
@@ -27,22 +27,22 @@ const UserRanking: React.FC<UserRankingsProps> = ({ user, type }) => {
     switch (type) {
       case "activity":
         if ("activity_score" in user) {
-          return `${user.activity_score} activity points`;
+          return `${user.activity_score} ポイント`;
         }
         break;
       case "contribution":
         if ("contribution_count" in user) {
-          return `${user.contribution_count} contributions`;
+          return `${user.contribution_count} コントリビューション`;
         }
         break;
       case "star":
         if ("total_stars" in user) {
-          return `${user.total_stars} stars`;
+          return `${user.total_stars} スター`;
         }
         break;
       case "qiita":
         if ("score" in user) {
-          return `${user.score}'s Qiita posts`;
+          return `${user.score} 投稿`;
         }
       default:
         return "";
@@ -53,57 +53,60 @@ const UserRanking: React.FC<UserRankingsProps> = ({ user, type }) => {
 
   return (
     <Link href={`/my-page/${user.user_id}`} underline="none">
-      <ListItemButton
-        sx={{
-          paddingTop: 0.5,
-          paddingBottom: 0.5,
+  <ListItemButton
+    sx={{
+      paddingTop: 0.5,
+      paddingBottom: 0.5,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+    }}
+  >
+    <Box sx={{ display: "flex", alignItems: "center" }}>
+      {user.rank <= 3 ? (
+        <EmojiEventsIcon sx={{ color: rankColor, width: 45, height: 45, ml: 14 }} />
+      ) : (
+        <ListItemText
+          primary={user.rank}
+          primaryTypographyProps={{
+            sx: {
+              fontSize: "1.5rem",
+              width: "30px",
+              textAlign: "center",
+              ml: 15,
+              mr: 1,
+            },
+          }}
+        />
+      )}
+      <Image src={user.image} alt={user.name} width={55} height={55} style={{ marginLeft: 10 }} />
+      <ListItemText
+        primary={user.name}
+        primaryTypographyProps={{
+          sx: {
+            fontWeight: 600,
+            fontSize: "1.25rem",
+            color: "black",
+            whiteSpace: "nowrap",
+            marginLeft: 4,
+          },
         }}
-      >
-        {user.rank >= 3 ? (
-          <ListItemText>{user.rank}</ListItemText>
-        ) : (
-          <EmojiEventsIcon sx={{ color: rankColor, width: 45, height: 45 }} />
-        )}
-        <Box sx={{ display: "flex", alignItems: "center", ml: 1 }}>
-          <Image src={user.image} alt={user.name} width={55} height={55} />
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "row",
-              alignItems: "center",
-              ml: 2,
-            }}
-          >
-            <ListItemText
-              primary={user.name}
-              primaryTypographyProps={{
-                sx: {
-                  fontWeight: 600,
-                  fontSize: "1.25rem",
-                  color: "black",
-                },
-              }}
-            />
-
-            <ListItemText
-              primary={getScore(user, type)}
-              primaryTypographyProps={{
-                sx: {
-                  fontWeight: 400,
-                  fontSize: "large",
-                  color: "text.secondary",
-                  textAlign: "left",
-                  position: "absolute",
-                  left: 320,
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                },
-              }}
-            />
-          </Box>
-        </Box>
-      </ListItemButton>
-    </Link>
+      />
+    </Box>
+    <ListItemText
+      primary={getScore(user, type)}
+      primaryTypographyProps={{
+        sx: {
+          fontWeight: 400,
+          fontSize: "large",
+          color: "text.secondary",
+          textAlign: "right",
+          marginRight: 18
+        },
+      }}
+    />
+  </ListItemButton>
+</Link>
   );
 };
 


### PR DESCRIPTION
ランキング一覧のUIを修正しました。
やったこと
・テキストを日本語に
・各ランキングを中央に寄せる

![image](https://github.com/user-attachments/assets/19a7bd89-f3bb-44c7-9232-754860b23b48)
