### PR TITLE
おすすめユーザーのカードの修正

### DIFF
--- a/src/components/suggest-users/UserCard.tsx
+++ b/src/components/suggest-users/UserCard.tsx
@@ -17,7 +17,6 @@ type Props = {
 };
 
 const UserCard = ({ user, chipOption }: Props) => {
-  const router = useRouter();
   return (
     <Link
       href={`/my-page/${user.user_id}`}
@@ -42,6 +41,7 @@ const UserCard = ({ user, chipOption }: Props) => {
           alignItems: "flex-start",
           padding: "1rem", // paddingをremに変更
           boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+          width: "250px",
           height: "auto", // autoにして内容に応じて伸縮
           minHeight: "10rem", // 必要であれば最低限の高さを指定
         }}


### PR DESCRIPTION
## 編集
- おすすめユーザーページの横の長さを固定して横スクロールできるようにした。
<img width="1470" alt="スクリーンショット 2024-10-20 21 46 45" src="https://github.com/user-attachments/assets/bbca5475-da9e-44d4-a4e6-a2e1a5bf3fc5">
